### PR TITLE
fix 3 bugs & 2 optimization

### DIFF
--- a/AutoLabel.py
+++ b/AutoLabel.py
@@ -159,19 +159,19 @@ class MainWindow(QMainWindow, WindowMixin):
 
         # Create a widget for using default label # CheckBox加入到HBoxLayout中 再加入到Qwidget中，最后到VBoxLayout中
         # 这部分以后可以删除
-        self.useDefaultLabelCheckbox = QCheckBox(getStr('useDefaultLabel'))
-        self.useDefaultLabelCheckbox.setChecked(False)
-        self.defaultLabelTextLine = QLineEdit()
-        useDefaultLabelQHBoxLayout = QHBoxLayout()
-        useDefaultLabelQHBoxLayout.addWidget(self.useDefaultLabelCheckbox)
-        useDefaultLabelQHBoxLayout.addWidget(self.defaultLabelTextLine)
-        useDefaultLabelContainer = QWidget()
-        useDefaultLabelContainer.setLayout(useDefaultLabelQHBoxLayout)
+        # self.useDefaultLabelCheckbox = QCheckBox(getStr('useDefaultLabel'))
+        # self.useDefaultLabelCheckbox.setChecked(False)
+        # self.defaultLabelTextLine = QLineEdit()
+        # useDefaultLabelQHBoxLayout = QHBoxLayout()
+        # useDefaultLabelQHBoxLayout.addWidget(self.useDefaultLabelCheckbox)
+        # useDefaultLabelQHBoxLayout.addWidget(self.defaultLabelTextLine)
+        # useDefaultLabelContainer = QWidget()
+        # useDefaultLabelContainer.setLayout(useDefaultLabelQHBoxLayout)
 
         # Create a widget for edit and diffc button
-        self.diffcButton = QCheckBox(getStr('useDifficult'))
-        self.diffcButton.setChecked(False)
-        self.diffcButton.stateChanged.connect(self.btnstate)
+        # self.diffcButton = QCheckBox(getStr('useDifficult'))
+        # self.diffcButton.setChecked(False)
+        # self.diffcButton.stateChanged.connect(self.btnstate)
         self.editButton = QToolButton()
         self.reRecogButton = QToolButton()
         self.reRecogButton.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
@@ -194,8 +194,8 @@ class MainWindow(QMainWindow, WindowMixin):
         # Add some of widgets to listLayout
         # listLayout.addWidget(self.newButton) # ADD
         # listLayout.addWidget(self.editButton)
-        listLayout.addWidget(self.diffcButton)
-        listLayout.addWidget(useDefaultLabelContainer)
+        #listLayout.addWidget(self.diffcButton)
+        #listLayout.addWidget(useDefaultLabelContainer)
 
 
         # Create and add combobox for showing unique labels in group 显示不同标签用的
@@ -964,7 +964,7 @@ class MainWindow(QMainWindow, WindowMixin):
                 self.loadFile(filename)
 
     def iconitemDoubleClicked(self, item=None):
-        currIndex = self.mImgList.index(ustr(os.path.join(item.toolTip(),item.text())))
+        currIndex = self.mImgList.index(ustr(os.path.join(item.toolTip())))
         if currIndex < len(self.mImgList):
             filename = self.mImgList[currIndex]
             if filename:
@@ -1393,6 +1393,7 @@ class MainWindow(QMainWindow, WindowMixin):
 
                 iconWidgetItem = self.iconlist.item(index)
                 iconWidgetItem.setSelected(True)
+                self.iconlist.scrollToItem(iconWidgetItem)
             else:
                 self.fileListWidget.clear()
                 self.mImgList.clear()
@@ -1654,6 +1655,7 @@ class MainWindow(QMainWindow, WindowMixin):
             self.fileListWidget.addItem(item)
 
         print('dirPath in importDirImages is',dirpath)
+        self.iconlist.clear()
         self.additems(dirpath)
         # AutoRec.setEnabled(True) # TODO: 刚开始时应该不能点击
 
@@ -1698,7 +1700,7 @@ class MainWindow(QMainWindow, WindowMixin):
         if currIndex - 1 >= 0:
             filename = self.mImgList[currIndex - 1]
             if filename:
-                self.c(filename)
+                self.loadFile(filename)
 
     def openNextImg(self, _value=False):
         # Proceding prev image without dialog if having any label
@@ -1751,6 +1753,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self.fileListWidget.addItem(filename)
 
         print('opened image is',filename)
+        self.iconlist.clear()
         self.additems(None)
 
     def updateFileListIcon(self, filename):
@@ -1986,9 +1989,10 @@ class MainWindow(QMainWindow, WindowMixin):
         # 读取和显示缩略图        
         for file in self.mImgList:
             pix = QPixmap(file)
-            filedir, filename = os.path.split(file)
-            item = QListWidgetItem(QIcon(pix.scaled(100, 100, Qt.KeepAspectRatio, Qt.SmoothTransformation)),filename)
-            item.setToolTip(filedir)
+            _, filename = os.path.split(file)
+            filename, _ = os.path.splitext(filename)
+            item = QListWidgetItem(QIcon(pix.scaled(100, 100, Qt.KeepAspectRatio, Qt.SmoothTransformation)),filename[:10])
+            item.setToolTip(file)
             self.iconlist.addItem(item)
 
     def autoRecognition(self):

--- a/libs/settings.py
+++ b/libs/settings.py
@@ -8,7 +8,7 @@ class Settings(object):
         # Be default, the home will be in the same folder as labelImg
         home = os.path.expanduser("~")
         self.data = {}
-        self.path = os.path.join(home, '.labelImgSettings.pkl')
+        self.path = os.path.join(home, '.autoOCRSettings.pkl')
 
     def __setitem__(self, key, value):
         self.data[key] = value


### PR DESCRIPTION
bugs
1缩略图：打开某个路径之后，再次打开其他路径，上一个路径中的图片仍然会保留在缩略图中
2缩略图：点击NextImg到最后一张图片后，再点击PrevImg后闪退
3缩略图：打开单张图片后，双击缩略图后闪退
优化：
缩略图：图片名称长度设置只显示前10个字符、不显示图片格式
缩略图：切换到靠后的图片时，缩略图无法同步滚动
删除冗余功能（Difficult、Use Default Label等）