### PR TITLE
fix 3 bugs & optimize 2 features

### DIFF
--- a/AutoLabel.py
+++ b/AutoLabel.py
@@ -94,7 +94,7 @@ class MainWindow(QMainWindow, WindowMixin):
         settings = self.settings
 
         # Load string bundle for i18n
-        self.stringBundle = StringBundle.getBundle()
+        self.stringBundle = StringBundle.getBundle(localeStr="zh-CN")
         getStr = lambda strId: self.stringBundle.getString(strId)
 
         # Save as Pascal voc xml
@@ -106,6 +106,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self.dirname = None
         self.labelHist = []
         self.lastOpenDir = None
+        self.result_dic = []
 
         # Whether we need to save or not.
         self.dirty = False
@@ -288,8 +289,12 @@ class MainWindow(QMainWindow, WindowMixin):
         m = (0,0,0,0)
         hlayout.setSpacing(0)
         hlayout.setContentsMargins(*m)
-        self.preButton = ToolButton()
+        self.preButton = QToolButton()
         self.preButton.setFixedHeight(100)
+        self.preButton.setText("prev")
+        self.preButton.setIcon(newIcon("prev", 80))
+        self.preButton.setIconSize(QSize(80, 80))
+        self.preButton.clicked.connect(self.openPrevImg)
         self.preButton.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
         self.iconlist = QListWidget()
         self.iconlist.setViewMode(QListView.IconMode)
@@ -299,10 +304,15 @@ class MainWindow(QMainWindow, WindowMixin):
         self.iconlist.setMovement(False)
         self.iconlist.setResizeMode(QListView.Adjust)
         self.iconlist.itemDoubleClicked.connect(self.iconitemDoubleClicked)
-        self.nextButton = ToolButton()
+        self.nextButton = QToolButton()
         self.nextButton.setFixedHeight(100)
+        self.nextButton.setText("next")
+        self.nextButton.setIcon(newIcon("next", 80))
+        self.nextButton.setIconSize(QSize(80, 80))
+        self.nextButton.clicked.connect(self.openNextImg)
         self.nextButton.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
         
+
         hlayout.addWidget(self.preButton)
         hlayout.addWidget(self.iconlist)
         hlayout.addWidget(self.nextButton)
@@ -491,8 +501,8 @@ class MainWindow(QMainWindow, WindowMixin):
         self.SaveButton.setDefaultAction(save)
         self.AutoRecognition.setDefaultAction(AutoRec)
         self.reRecogButton.setDefaultAction(reRec)
-        self.preButton.setDefaultAction(openPrevImg)
-        self.nextButton.setDefaultAction(openNextImg)
+        # self.preButton.setDefaultAction(openPrevImg)
+        # self.nextButton.setDefaultAction(openNextImg)
 
         ############# Zoom layout ##############
         zoomLayout = QHBoxLayout()
@@ -810,6 +820,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self.canvas.resetState()
         self.labelCoordinates.clear()
         self.comboBox.cb.clear()
+        self.result_dic = []
 
     def currentItem(self):
         items = self.labelList.selectedItems()
@@ -971,10 +982,8 @@ class MainWindow(QMainWindow, WindowMixin):
                 self.loadFile(filename)
 
     def CanvasSizeChange(self):
-        print(self.imgsplider.value())
-        print(type(self.imgsplider.value()))
-        print(self.imgsplider.value()/10)
-        self.zoomWidget.setValue(self.zoomWidgetValue + self.imgsplider.value())
+        if len(self.mImgList) > 0:
+            self.zoomWidget.setValue(self.zoomWidgetValue + self.imgsplider.value())
 
     # Add chris
     def btnstate(self, item= None):
@@ -1122,6 +1131,14 @@ class MainWindow(QMainWindow, WindowMixin):
 
         shapes = [format_shape(shape) for shape in self.canvas.shapes] # 从canvas中读入shape 并且获得标记
         # Can add differrent annotation formats here
+
+        if self.model == 'paddle':
+            for box in self.result_dic:
+                # if len(box)==1: # 只有框
+                #     trans_dic = {"label": ' ', "points": box[0], 'difficult': False}
+                trans_dic = {"label": box[1][0], "points": box[0], 'difficult': False}
+                shapes.append(trans_dic)
+
         try:
             if self.labelFileFormat == LabelFileFormat.PASCAL_VOC:
                 if annotationFilePath[-4:].lower() != ".xml":
@@ -1176,6 +1193,8 @@ class MainWindow(QMainWindow, WindowMixin):
                 # if len(box)==1: # 只有框
                 #     trans_dic = {"label": ' ', "points": box[0], 'difficult': False}
                 trans_dic = {"label": box[1][0], "points": box[0], 'difficult': False}
+                if trans_dic["label"] is "":
+                    continue
                 shapes.append(trans_dic)
         # shapes = [format_shape(shape) for shape in self.canvas.shapes] # 从canvas中读入shape 并且获得标记
         # shapes = [format_shape(shape) for shape in self.result] # 每个都是dict
@@ -1378,10 +1397,9 @@ class MainWindow(QMainWindow, WindowMixin):
 
         # Make sure that filePath is a regular python string, rather than QString
         filePath = ustr(filePath)
-
         # Fix bug: An index error after select a directory when open a new file.
         unicodeFilePath = ustr(filePath) # 路径
-        unicodeFilePath = os.path.abspath(unicodeFilePath)
+        # unicodeFilePath = os.path.abspath(unicodeFilePath)
         # Tzutalin 20160906 : Add file list and dock to move faster
         # Highlight the file item
         if unicodeFilePath and self.fileListWidget.count() > 0:
@@ -1744,6 +1762,7 @@ class MainWindow(QMainWindow, WindowMixin):
             # print('filename in openfile is ', self.filePath)
         self.filePath = None
         self.fileListWidget.clear()
+        self.iconlist.clear()
         self.mImgList = [filename] # 将所有文件读入mImgList中
         self.openNextImg()
         if self.validAnnoExist(filename) is True:
@@ -1751,10 +1770,9 @@ class MainWindow(QMainWindow, WindowMixin):
         else:
             item = QListWidgetItem(newIcon('close'), filename)
         self.fileListWidget.addItem(filename)
-
-        print('opened image is',filename)
-        self.iconlist.clear()
         self.additems(None)
+        print('opened image is',filename)
+        
 
     def updateFileListIcon(self, filename):
         pass
@@ -1991,7 +2009,8 @@ class MainWindow(QMainWindow, WindowMixin):
             pix = QPixmap(file)
             _, filename = os.path.split(file)
             filename, _ = os.path.splitext(filename)
-            item = QListWidgetItem(QIcon(pix.scaled(100, 100, Qt.KeepAspectRatio, Qt.SmoothTransformation)),filename[:10])
+            # item = QListWidgetItem(QIcon(pix.scaled(100, 100, Qt.KeepAspectRatio, Qt.SmoothTransformation)),filename[:10])
+            item = QListWidgetItem(QIcon(pix.scaled(100, 100, Qt.IgnoreAspectRatio, Qt.FastTransformation)),filename[:10])
             item.setToolTip(file)
             self.iconlist.addItem(item)
 
@@ -2076,7 +2095,8 @@ class MainWindow(QMainWindow, WindowMixin):
                 # self.filePath 存在
                 # self.filePath = Imgpath  # 文件路径
                 # 保存
-                self.saveFile(mode='Auto')
+                self.setDirty()
+                # self.saveFile(mode='Auto')
             elif len(self.result_dic)==len(self.canvas.shapes) and rec_flag == 0:
                 QMessageBox.information(self, "Information", "Not any change!")
             else:
@@ -2090,6 +2110,7 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def autolcm(self):
         print('autolabelchoosemodel')
+
 
 def inverted(color):
     return QColor(*[255 - v for v in color.getRgb()])

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -13,8 +13,11 @@ except ImportError:
     from PyQt4.QtCore import *
 
 
-def newIcon(icon):
-    return QIcon(':/' + icon)
+def newIcon(icon, iconSize=None):
+    if iconSize is not None:
+        return QIcon(QIcon(':/' + icon).pixmap(iconSize,iconSize))
+    else:
+        return QIcon(':/' + icon)
 
 
 def newButton(text, icon=None, slot=None):
@@ -27,11 +30,14 @@ def newButton(text, icon=None, slot=None):
 
 
 def newAction(parent, text, slot=None, shortcut=None, icon=None,
-              tip=None, checkable=False, enabled=True):
+              tip=None, checkable=False, enabled=True, iconSize=None):
     """Create a new action and assign callbacks, shortcuts, etc."""
     a = QAction(text, parent)
     if icon is not None:
-        a.setIcon(newIcon(icon))
+        if iconSize is not None:
+            a.setIcon(newIcon(icon, iconSize))
+        else:
+            a.setIcon(newIcon(icon))
     if shortcut is not None:
         if isinstance(shortcut, (list, tuple)):
             a.setShortcuts(shortcut)


### PR DESCRIPTION
bugs:
1.自动识别：报错闪退，例：demo/demo5.png
2.保存：在未使用自动标注的前提下，打开一张未被标记的图片，新建框后点击重新识别，识别完成后无法点击Save
3.单张图片模式下，双击文件列表或缩略图，文件和缩略图都会消失
optimizations:
缩略图：组件长度无法更改、前后图片按钮图标位置需要调整到正中间
缩略图：图片垂直居中

请针对这五部分着重测试。
